### PR TITLE
fix when e.RowIndex == -1 on dataGridView Initialisation

### DIFF
--- a/DarkUI/Controls/DarkDataGridView.cs
+++ b/DarkUI/Controls/DarkDataGridView.cs
@@ -145,7 +145,7 @@ namespace DarkUI.Controls
         {
             // Raise a data event update if necessary
             var dataSource = DataSource as IBindingList;
-            if (dataSource != null)
+            if (dataSource != null && e.RowIndex >= 0)
             {
                 object obj = dataSource[e.RowIndex];
                 if (!(obj is INotifyPropertyChanged))


### PR DESCRIPTION
Happens on  components initialization, when a column header text is set - the datasource is not set yet, but not null either.